### PR TITLE
Fix typo in hybrid palette comment

### DIFF
--- a/src/palette/hybrid.rs
+++ b/src/palette/hybrid.rs
@@ -276,7 +276,7 @@ impl<const INLINE_PALETTE_THRESHOLD: usize, T: Eq + Hash + Clone> Palette<T>
                         return (i, actual_new_index_size);
                     }
                 }
-                // No free spot available, need to swich to hashmap
+                // No free spot available, need to switch to hashmap
                 self.switch_to_hashmap();
                 self.insert_new(entry)
             }


### PR DESCRIPTION
## Summary
- fix a comment typo in `src/palette/hybrid.rs`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683f8c816394832a8ad7427a36adcf38